### PR TITLE
Media server adapter factory, improvements to media element creation

### DIFF
--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -83,6 +83,12 @@ processes:
   - path: './lib/audio/AudioProcess.js'
   - path: './lib/stream/StreamProcess.js'
 
+media-server-adapters:
+  - path: 'kurento/kurento.js'
+    name: 'Kurento'
+  - path: 'freeswitch/freeswitch.js'
+    name: 'Freeswitch'
+
 conference-media-specs:
   codec_video_main: "H264"
   codec_video_content: "H264"

--- a/lib/mcs-core/lib/adapters/adapter-factory.js
+++ b/lib/mcs-core/lib/adapters/adapter-factory.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const config = require('config');
+const Logger = require('../utils/logger');
+const EventEmitter = require('events').EventEmitter;
+const C = require('../constants/constants');
+const Balancer = require('../media/balancer');
+// Media server adapters
+const configuredAdapters = config.get('media-server-adapters');
+const adapterPathPrefix = './';
+// Preset configured adapters
+let adapters = [];
+const defaultAdapters = {'contentAdapter': 'Kurento', 'videoAdapter': 'Kurento', 'audioAdapter': 'Freeswitch'};
+
+configuredAdapters.forEach(a => {
+  try {
+    const { path, name } = a;
+    const adapter = require(`${adapterPathPrefix}${path}`);
+    adapters.push({ adapter, name });
+  } catch (e) {
+    Logger.error('[mcs-adapter-factory] Could not add configured adapter', a, e);
+  }
+});
+
+Logger.debug('[mcs-adapter-factory] Configured media server adapters', adapters);
+
+let instance = null;
+
+class AdapterFactory extends EventEmitter {
+  constructor () {
+    super();
+    if (instance == null) {
+      instance = this;
+    }
+    return instance;
+  }
+
+  isComposedAdapter (adapter) {
+    if (typeof adapter === 'object') {
+      return true;
+    }
+
+    return false;
+  }
+
+  findAdapter (adapterName) {
+    let adapter = null;
+    const adapterObj = adapters.find(a => a.name === adapterName);
+    if (adapterObj) {
+      const constructor = adapterObj.adapter;
+      adapter = new constructor(Balancer);
+    }
+
+    return adapter;
+  }
+
+  getAdapters (adapterReq) {
+    let adapters = {};
+    let defaultAdaptersMap = defaultAdapters;
+
+    const findComposedAdapters = (aMap) => {
+      Object.keys(aMap).forEach(r => {
+        const a = this.findAdapter(aMap[r]);
+        if (a) {
+          adapters[r] = a;
+          delete defaultAdaptersMap[r];
+        }
+      });
+    };
+
+    if (this.isComposedAdapter(adapterReq)) {
+      findComposedAdapters(adapterReq);
+      findComposedAdapters(defaultAdaptersMap);
+      return adapters;
+    } else {
+      const a = this.findAdapter(adapterReq);
+      return {'videoAdapter': a, 'audioAdapter': a, 'contentAdapter': a};
+    }
+  }
+}
+
+module.exports = new AdapterFactory();

--- a/lib/mcs-core/lib/adapters/adapter-factory.js
+++ b/lib/mcs-core/lib/adapters/adapter-factory.js
@@ -22,7 +22,7 @@ configuredAdapters.forEach(a => {
   }
 });
 
-Logger.debug('[mcs-adapter-factory] Configured media server adapters', adapters);
+Logger.debug('[mcs-adapter-factory] Configured media server adapters', adapters.map(a => a.name));
 
 let instance = null;
 
@@ -56,7 +56,7 @@ class AdapterFactory extends EventEmitter {
 
   getAdapters (adapterReq) {
     let adapters = {};
-    let defaultAdaptersMap = defaultAdapters;
+    let defaultAdaptersMap = { ... defaultAdapters };
 
     const findComposedAdapters = (aMap) => {
       Object.keys(aMap).forEach(r => {

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -43,13 +43,6 @@ module.exports = class MediaController {
       const user = await this.createUserMCS(roomId, type, params);
       room.setUser(user);
 
-      if (params.sdp) {
-        session = user.addSdp(params.sdp);
-      }
-      if (params.uri) {
-        session = user.addUri(params.sdp);
-      }
-
       Logger.info("[mcs-controller] Resolving user " + user.id);
       return Promise.resolve(user.id);
     }

--- a/lib/mcs-core/lib/media/media-factory.js
+++ b/lib/mcs-core/lib/media/media-factory.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const config = require('config');
 const Logger = require('../utils/logger');
 const EventEmitter = require('events').EventEmitter;
 const C = require('../constants/constants');

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -13,6 +13,7 @@ const Balancer = require('../media/balancer');
 const config = require('config');
 const Logger = require('../utils/logger');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
+const AdapterFactory = require('../adapters/adapter-factory');
 const { handleError } = require('../utils/util');
 
 const LOG_PREFIX = "[mcs-media-session]";
@@ -54,13 +55,9 @@ module.exports = class MediaSession {
     this._customIdentifier = options.customIdentifier? options.customIdentifier : null;
     // Media server interface based on given adapter
     this._isComposedAdapter = isComposedAdapter(this._adapter);
-    if (this._isComposedAdapter) {
-      this._audioAdapter = MediaSession.getAdapter(this._adapter.audio);
-      this._videoAdapter = MediaSession.getAdapter(this._adapter.video);
-    } else {
-      this._audioAdapter = MediaSession.getAdapter(this._adapter);
-      this._videoAdapter = MediaSession.getAdapter(this._adapter);
-    }
+
+    this._adapters = AdapterFactory.getAdapters(this._adapter);
+
     // Media server adapter ID for this session's element
     this.videoMediaElement;
     this.audioMediaElement;
@@ -105,39 +102,29 @@ module.exports = class MediaSession {
     this._status = C.STATUS.STARTING;
     try {
       let mediaElement, host;
+      const {
+        videoAdapter,
+        audioAdapter,
+        contentAdapter
+      } = this._adapters;
 
-      if (this._isComposedAdapter) {
-        ({ mediaElement, host } = await this._videoAdapter.createMediaElement(this.roomId, this._type, this._options));
+      ({ mediaElement, host } = await videoAdapter.createMediaElement(this.roomId, this._type, this._options));
 
-        this.videoMediaElement = mediaElement;
-        this.videoHost = host;
+      this.videoMediaElement = mediaElement;
+      this.videoHost = host;
 
-        if (this._mediaProfile === 'content') {
-          this.contentMediaElement = mediaElement;
-          this.contentHost = host;
-        }
-
-        ({ mediaElement, host } = await this._audioAdapter.createMediaElement(this.roomId, this._type, this._options));
-
-        this.audioMediaElement = mediaElement;
-        this.audioHost = host;
-
-        this._upstartMediaElement(this._videoAdapter, this.videoMediaElement);
-        this._upstartMediaElement(this._audioAdapter, this.audioMediaElement);
-      } else {
-        ({ mediaElement, host } = await this._videoAdapter.createMediaElement(this.roomId, this._type, this._options));
-
-        this.videoMediaElement = mediaElement;
-        this.videoHost = host;
-
-        if (this._mediaProfile === 'content') {
-          this.contentMediaElement = mediaElement;
-          this.contentHost = host;
-        }
-
-        this._upstartMediaElement(this._videoAdapter, this.videoMediaElement);
+      if (this._mediaProfile === 'content') {
+        this.contentMediaElement = mediaElement;
+        this.contentHost = host;
       }
 
+      ({ mediaElement, host } = await audioAdapter.createMediaElement(this.roomId, this._type, this._options));
+
+      this.audioMediaElement = mediaElement;
+      this.audioHost = host;
+
+      this._upstartMediaElement(videoAdapter, this.videoMediaElement);
+      this._upstartMediaElement(audioAdapter, this.audioMediaElement);
       return;
     }
     catch (err) {
@@ -189,30 +176,25 @@ module.exports = class MediaSession {
     if (this._status === C.STATUS.STARTED || this._states === C.STATUS.STARTING) {
       this._status = C.STATUS.STOPPING;
       try {
-        await this._videoAdapter.stop(this.roomId, this._type, this.videoMediaElement);
+        const {
+          videoAdapter,
+          audioAdapter,
+          contentAdapter
+        } = this._adapters;
 
-        if (this._isComposedAdapter) {
-          await this._audioAdapter.stop(this.roomId, this._type, this.audioMediaElement);
+        if (this.videoMediaElement) {
+          await videoAdapter.stop(this.roomId, this._type, this.videoMediaElement);
+          this.balancer.decrementHostStreams(this.videoHost.id, 'video');
+        }
+
+        if (this.audioMediaElement) {
+          await audioAdapter.stop(this.roomId, this._type, this.audioMediaElement);
+          this.balancer.decrementHostStreams(this.audioHost.id, 'audio');
         }
 
         this._status = C.STATUS.STOPPED;
         Logger.info("[mcs-media-session] Session", this.id, "stopped with status", this._status);
         this.emitter.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.id });
-
-        if (this.hasVideo) {
-          if (this._isComposedAdapter && this._adapter.video === C.STRING.KURENTO ||
-            this._adapter === C.STRING.KURENTO) {
-            this.balancer.decrementHostStreams(this.videoHost.id, 'video');
-          }
-        }
-
-        if (this.hasAudio) {
-          if (this._isComposedAdapter && this._adapter.audio === C.STRING.KURENTO) {
-            this.balancer.decrementHostStreams(this.audioHost.id, 'audio');
-          } else if (this._adapter === C.STRING.KURENTO) {
-            this.balancer.decrementHostStreams(this.videoHost.id, 'audio');
-          }
-        }
 
         return Promise.resolve();
       }
@@ -227,19 +209,26 @@ module.exports = class MediaSession {
 
   async connect (sink, type = 'ALL') {
     try {
+      const {
+        videoAdapter,
+        audioAdapter,
+        contentAdapter
+      } = this._adapters;
+
       let adapter, sourceElement, sinkElement;
       Logger.info("[mcs-media-session] Connecting", this.id, "=>", sink.id, "with type", type);
+
       if (type === 'CONTENT') {
-        adapter = this._videoAdapter;
+        adapter = contentAdapter;
         sourceElement = this.contentMediaElement;
         sinkElement = sink.videoMediaElement;
         type = 'VIDEO';
       } else if (type === 'AUDIO') {
-        adapter = this._audioAdapter;
+        adapter = audioAdapter;
         sourceElement = this.audioMediaElement;
         sinkElement = sink.audioMediaElement;
       } else {
-        adapter = this._videoAdapter;
+        adapter = videoAdapter;
         sourceElement = this.videoMediaElement;
         sinkElement = sink.videoMediaElement;
       }

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -80,24 +80,6 @@ module.exports = class MediaSession {
     this._iceSubscription = false;
   }
 
-  static getAdapter (adapter) {
-    let obj = null;
-
-    Logger.info("[mcs-media-session] Session is using the", adapter, "adapter");
-
-    switch (adapter) {
-      case C.STRING.FREESWITCH:
-        obj = new Freeswitch(Balancer);
-        break;
-      default:
-        obj = new Kurento(Balancer);
-        break;
-    }
-
-    return obj;
-  }
-
-
   async start () {
     this._status = C.STATUS.STARTING;
     return;
@@ -256,7 +238,6 @@ module.exports = class MediaSession {
   }
 
   _dispatchMediaStateEvent (event) {
-
     if (!this._mediaStateSubscription) {
       Logger.debug("[mcs-media-session] Media session", this.id, "queuing event", { mediaId: this.id, ...event });
       this.eventQueue.push(event);

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -136,14 +136,14 @@ module.exports = class MediaSession {
 
         if (this.videoMediaElement) {
           await videoAdapter.stop(this.roomId, this._type, this.videoMediaElement);
-          if (this._answer.hasAvailableVideoCodec()) {
+          if (this._answer && this._answer.hasAvailableVideoCodec()) {
             this.balancer.decrementHostStreams(this.videoHost.id, 'video');
           }
         }
 
         if (this.audioMediaElement) {
           await audioAdapter.stop(this.roomId, this._type, this.audioMediaElement);
-          if (this._answer.hasAvailableAudioCodec()) {
+          if (this._answer && this._answer.hasAvailableAudioCodec()) {
             this.balancer.decrementHostStreams(this.videoHost.id, 'audio');
           }
         }

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -100,37 +100,7 @@ module.exports = class MediaSession {
 
   async start () {
     this._status = C.STATUS.STARTING;
-    try {
-      let mediaElement, host;
-      const {
-        videoAdapter,
-        audioAdapter,
-        contentAdapter
-      } = this._adapters;
-
-      ({ mediaElement, host } = await videoAdapter.createMediaElement(this.roomId, this._type, this._options));
-
-      this.videoMediaElement = mediaElement;
-      this.videoHost = host;
-
-      if (this._mediaProfile === 'content') {
-        this.contentMediaElement = mediaElement;
-        this.contentHost = host;
-      }
-
-      ({ mediaElement, host } = await audioAdapter.createMediaElement(this.roomId, this._type, this._options));
-
-      this.audioMediaElement = mediaElement;
-      this.audioHost = host;
-
-      this._upstartMediaElement(videoAdapter, this.videoMediaElement);
-      this._upstartMediaElement(audioAdapter, this.audioMediaElement);
-      return;
-    }
-    catch (err) {
-      err = this._handleError(err);
-      throw err;
-    }
+    return;
   }
 
   async _upstartMediaElement (adapter, element) {
@@ -184,12 +154,20 @@ module.exports = class MediaSession {
 
         if (this.videoMediaElement) {
           await videoAdapter.stop(this.roomId, this._type, this.videoMediaElement);
-          this.balancer.decrementHostStreams(this.videoHost.id, 'video');
+          if (this._answer.hasAvailableVideoCodec()) {
+            this.balancer.decrementHostStreams(this.videoHost.id, 'video');
+          }
         }
 
         if (this.audioMediaElement) {
           await audioAdapter.stop(this.roomId, this._type, this.audioMediaElement);
-          this.balancer.decrementHostStreams(this.audioHost.id, 'audio');
+          if (this._answer.hasAvailableAudioCodec()) {
+            this.balancer.decrementHostStreams(this.videoHost.id, 'audio');
+          }
+        }
+
+        if (this.contentMediaElement) {
+          await contentAdapter.stop(this.roomId, this._type, this.contentMediaElement);
         }
 
         this._status = C.STATUS.STOPPED;

--- a/lib/mcs-core/lib/model/recording-session.js
+++ b/lib/mcs-core/lib/model/recording-session.js
@@ -8,6 +8,7 @@
 const config = require('config');
 const MediaSession = require('./media-session');
 const Logger = require('../utils/logger');
+const C = require('../constants/constants');
 
 module.exports = class RecordingSession extends MediaSession {
   constructor(room, user, recordingPath) {
@@ -22,11 +23,31 @@ module.exports = class RecordingSession extends MediaSession {
     this.filename = uri;
   }
 
+  async _createMainMediaElement () {
+    let mediaElement, host;
+    const {
+      videoAdapter,
+    } = this._adapters;
+
+    ({ mediaElement, host } = await videoAdapter.createMediaElement(this.roomId, this._type, this._options));
+
+    this.videoMediaElement = mediaElement;
+    this.videoHost = host;
+
+    return { mediaElement, host };
+  }
+
+
   process () {
     return new Promise(async (resolve, reject) => {
       try {
+        const {
+          videoAdapter,
+        } = this._adapters;
+
+        await this._createMainMediaElement();
         Logger.debug("[mcs-recording-session] Started recording", this.id, "at", this.filename);
-        await this._videoAdapter.startRecording(this.videoMediaElement);
+        await videoAdapter.startRecording(this.videoMediaElement);
         return resolve(this.id);
       } catch (e) {
         return reject(this._handleError(e));

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -11,6 +11,7 @@ const rid = require('readable-id');
 const MediaSession = require('./media-session');
 const config = require('config');
 const Logger = require('../utils/logger');
+const AdapterFactory = require('../adapters/adapter-factory');
 const MEDIA_SPECS = config.get('conference-media-specs');
 
 module.exports = class SdpSession extends MediaSession {
@@ -49,16 +50,22 @@ module.exports = class SdpSession extends MediaSession {
   }
 
   async _defileAndProcess () {
+    const {
+      videoAdapter,
+      audioAdapter,
+      contentAdapter
+    } = this._adapters;
+
     const videoDescription = this._offer.mainVideoSdp;
     const audioDescription = this._offer.audioSdp;
     Logger.trace('[mcs-sdp-session] Defiling this beloved SDP for session', this.id, videoDescription, audioDescription);
-    const videoAnswer = await this._videoAdapter.processOffer(this.videoMediaElement,
+    const videoAnswer = videoAdapter.processOffer(this.videoMediaElement,
       videoDescription, { name: this._name });
-    const audioAnswer = await this._audioAdapter.processOffer(this.audioMediaElement,
+    const audioAnswer = audioAdapter.processOffer(this.audioMediaElement,
       audioDescription, { name: this._name });
 
-    this._audioAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.audioMediaElement, this.stop.bind(this));
-    this._videoAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.videoMediaElement, this.stop.bind(this))
+    audioAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.audioMediaElement, this.stop.bind(this));
+    videoAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.videoMediaElement, this.stop.bind(this))
 
     this.setAnswer(audioAnswer + this._offer.removeSessionDescription(videoAnswer));
     return this._answer._plainSdp;
@@ -68,12 +75,18 @@ module.exports = class SdpSession extends MediaSession {
   renegotiateStreams () {
     return new Promise(async (resolve, reject) => {
       try {
+        const {
+          videoAdapter,
+          audioAdapter,
+          contentAdapter
+        } = this._adapters;
+
         if (this._offer.contentVideoSdp) {
-          const { mediaElement, host } = await this._videoAdapter.createMediaElement(this.roomId, this._type, this._options);
+          const { mediaElement, host } = await contentAdapter.createMediaElement(this.roomId, this._type, this._options);
 
           this.contentMediaElement = mediaElement;
           this.contentHost = host;
-          let contentAnswer = await this._videoAdapter.processOffer(this.contentMediaElement,
+          let contentAnswer = await videoAdapter.processOffer(this.contentMediaElement,
             this._offer.contentVideoSdp,
             { name: this._name }
           );
@@ -90,21 +103,28 @@ module.exports = class SdpSession extends MediaSession {
   process () {
     return new Promise(async (resolve, reject) => {
       try {
+        const {
+          videoAdapter,
+          audioAdapter,
+          contentAdapter
+        } = this._adapters;
+
         let answer;
         if (this._shouldRenegotiate) {
           answer = await this.renegotiateStreams();
           return resolve(answer);
         }
 
-        if (this._isComposedAdapter) {
+        if (AdapterFactory.isComposedAdapter(this._adapter)) {
           answer = await this._defileAndProcess(this._offer);
         } else {
+          // The adapter is the same for all media types, so either one will suffice
           let offer = this._offer ? this._offer.plainSdp : null;
-          answer = await this._videoAdapter.processOffer(this.videoMediaElement,
+          answer = await videoAdapter.processOffer(this.videoMediaElement,
             offer,
             { name: this._name }
           );
-          this._videoAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.videoMediaElement, this.stop.bind(this));
+          videoAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.videoMediaElement, this.stop.bind(this));
 
           this.setAnswer(answer);
         }
@@ -129,8 +149,9 @@ module.exports = class SdpSession extends MediaSession {
           answer = SdpWrapper.nonPureReplaceServerIpv4(answer, this.videoHost.ip);
         }
 
+        // TODO gather candidates for every media element in the session
         if (this._type === 'WebRtcEndpoint') {
-          await this._videoAdapter.gatherCandidates(this.videoMediaElement);
+          await videoAdapter.gatherCandidates(this.videoMediaElement);
         }
 
         this._updateHostLoad();
@@ -149,7 +170,13 @@ module.exports = class SdpSession extends MediaSession {
   addIceCandidate (candidate) {
     return new Promise(async (resolve, reject) => {
       try {
-        await this._videoAdapter.addIceCandidate(this.videoMediaElement, candidate);
+        const {
+          videoAdapter,
+          audioAdapter,
+          contentAdapter
+        } = this._adapters;
+
+        await videoAdapter.addIceCandidate(this.videoMediaElement, candidate);
         resolve();
       }
       catch (err) {
@@ -171,11 +198,7 @@ module.exports = class SdpSession extends MediaSession {
     }
 
     if (this._answer.hasAvailableAudioCodec()) {
-      if (this._isComposedAdapter && this._adapter.audio === C.STRING.KURENTO) {
-        this.balancer.incrementHostStreams(this.audioHost.id, 'audio');
-      } else if (this._adapter === C.STRING.KURENTO) {
-        this.balancer.incrementHostStreams(this.videoHost.id, 'audio');
-      }
+      this.balancer.incrementHostStreams(this.audioHost.id, 'audio');
       this.hasAudio = true;
     }
   }

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -59,9 +59,9 @@ module.exports = class SdpSession extends MediaSession {
     const videoDescription = this._offer.mainVideoSdp;
     const audioDescription = this._offer.audioSdp;
     Logger.trace('[mcs-sdp-session] Defiling this beloved SDP for session', this.id, videoDescription, audioDescription);
-    const videoAnswer = videoAdapter.processOffer(this.videoMediaElement,
+    const videoAnswer = await videoAdapter.processOffer(this.videoMediaElement,
       videoDescription, { name: this._name });
-    const audioAnswer = audioAdapter.processOffer(this.audioMediaElement,
+    const audioAnswer = await audioAdapter.processOffer(this.audioMediaElement,
       audioDescription, { name: this._name });
 
     audioAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.audioMediaElement, this.stop.bind(this));
@@ -100,6 +100,97 @@ module.exports = class SdpSession extends MediaSession {
     });
   }
 
+  async _createMainMediaElement (referenceDescriptor) {
+    let mediaElement, host;
+    const {
+      videoAdapter,
+      audioAdapter,
+      contentAdapter
+    } = this._adapters;
+
+    if ((referenceDescriptor && referenceDescriptor.hasVideo) ||
+      !AdapterFactory.isComposedAdapter(this._adapter)) {
+      ({ mediaElement, host } = await videoAdapter.createMediaElement(this.roomId, this._type, this._options));
+
+      this.videoMediaElement = mediaElement;
+      this.videoHost = host;
+
+      // Audio and video are bundled
+      if (!AdapterFactory.isComposedAdapter(this._adapter)) {
+        this.audioMediaElement = mediaElement;
+        this.audioHost = host;
+      }
+
+      if (this._mediaProfile === 'content') {
+        this.contentMediaElement = mediaElement;
+        this.contentHost = host;
+      }
+
+      this._upstartMediaElement(videoAdapter, this.videoMediaElement);
+      return { mediaElement, host };
+    }
+  }
+
+  async _createAudioMediaElement (referenceDescriptor) {
+    let mediaElement, host;
+    const {
+      videoAdapter,
+      audioAdapter,
+      contentAdapter
+    } = this._adapters;
+
+    if ((referenceDescriptor && referenceDescriptor.hasAudio) ||
+      AdapterFactory.isComposedAdapter(this._adapter)) {
+      ({ mediaElement, host } = await audioAdapter.createMediaElement(this.roomId, this._type, this._options));
+
+      this.audioMediaElement = mediaElement;
+      this.audioHost = host;
+
+      this._upstartMediaElement(audioAdapter, this.audioMediaElement);
+
+      return { mediaElement, host };
+    }
+  }
+
+  async _createContentMediaElement (referenceDescriptor) {
+    let mediaElement, host;
+    const {
+      videoAdapter,
+      audioAdapter,
+      contentAdapter
+    } = this._adapters;
+
+    if ((referenceDescriptor && referenceDescriptor.hasContent) ||
+      AdapterFactory.isComposedAdapter(this._adapter)) {
+      ({ mediaElement, host } = await contentAdapter.createMediaElement(this.roomId, this._type, this._options));
+
+      this.contentMediaElement= mediaElement;
+      this.contentHost = host;
+
+      this._upstartMediaElement(audioAdapter, this.audioMediaElement);
+
+      return { mediaElement, host };
+    }
+  }
+
+  _createMediaElements () {
+    return new Promise(async (resolve, reject) => {
+      try {
+        let mediaElement, host;
+
+        const referenceDescriptor = this._offer? this._offer : this._answer;
+        await this._createMainMediaElement(referenceDescriptor);
+        await this._createAudioMediaElement(referenceDescriptor);
+        await this._createContentMediaElement(referenceDescriptor);
+        return resolve();
+      }
+      catch (err) {
+        err = this._handleError(err);
+        reject(err);
+      }
+    });
+  }
+
   process () {
     return new Promise(async (resolve, reject) => {
       try {
@@ -108,23 +199,27 @@ module.exports = class SdpSession extends MediaSession {
           audioAdapter,
           contentAdapter
         } = this._adapters;
-
         let answer;
+
         if (this._shouldRenegotiate) {
           answer = await this.renegotiateStreams();
           return resolve(answer);
         }
+
+        await this._createMediaElements();
 
         if (AdapterFactory.isComposedAdapter(this._adapter)) {
           answer = await this._defileAndProcess(this._offer);
         } else {
           // The adapter is the same for all media types, so either one will suffice
           let offer = this._offer ? this._offer.plainSdp : null;
-          answer = await videoAdapter.processOffer(this.videoMediaElement,
-            offer,
-            { name: this._name }
-          );
-          videoAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.videoMediaElement, this.stop.bind(this));
+          if (this.videoMediaElement) {
+            answer = await videoAdapter.processOffer(this.videoMediaElement,
+              offer,
+              { name: this._name }
+            );
+            videoAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.videoMediaElement, this.stop.bind(this));
+          }
 
           this.setAnswer(answer);
         }
@@ -135,21 +230,19 @@ module.exports = class SdpSession extends MediaSession {
 
         // Checks if the media server was able to find a compatible media line
         if (this._offer && answer) {
-          // TODO review codec checking
-          //if (!this._hasAvailableCodec()) {
-          //  return reject(this._handleError(C.ERROR.MEDIA_NO_AVAILABLE_CODEC));
-          //}
+          if (!this._hasAvailableCodec()) {
+            return reject(this._handleError(C.ERROR.MEDIA_NO_AVAILABLE_CODEC));
+          }
 
           this._mediaTypes.video = this._answer.hasAvailableVideoCodec();
           this._mediaTypes.audio = this._answer.hasAvailableAudioCodec();
         }
 
-        // TODO review the whole videoHost/audioHost flow, too messy
+        // Manual NAT traversal for when the media server is behind NAT
         if (answer && this._type !== 'WebRtcEndpoint') {
           answer = SdpWrapper.nonPureReplaceServerIpv4(answer, this.videoHost.ip);
         }
 
-        // TODO gather candidates for every media element in the session
         if (this._type === 'WebRtcEndpoint') {
           await videoAdapter.gatherCandidates(this.videoMediaElement);
         }


### PR DESCRIPTION
- Refactored media server adapter handling. An adapter factory was added and we can now just configure the adapters as plugins in the configuration file and if they're properly implemented they'll be automatically added to the application without additional code changes
- Refactored media element creation to follow the new adapter pattern and make it easier to handle multiple media elements and negotiate outbound content streams. It's better now, but there's still room for improvements in some parts of that code (mainly on `sdp-session`).
- Re-enabled codec compatibility checking
- Avoid creating unused media elements in sdp-session