### PR TITLE
Working multiple medias and outbound content

### DIFF
--- a/lib/mcs-core/lib/adapters/adapter-factory.js
+++ b/lib/mcs-core/lib/adapters/adapter-factory.js
@@ -9,20 +9,8 @@ const Balancer = require('../media/balancer');
 const configuredAdapters = config.get('media-server-adapters');
 const adapterPathPrefix = './';
 // Preset configured adapters
-let adapters = [];
 const defaultAdapters = {'contentAdapter': 'Kurento', 'videoAdapter': 'Kurento', 'audioAdapter': 'Freeswitch'};
 
-configuredAdapters.forEach(a => {
-  try {
-    const { path, name } = a;
-    const adapter = require(`${adapterPathPrefix}${path}`);
-    adapters.push({ adapter, name });
-  } catch (e) {
-    Logger.error('[mcs-adapter-factory] Could not add configured adapter', a, e);
-  }
-});
-
-Logger.debug('[mcs-adapter-factory] Configured media server adapters', adapters.map(a => a.name));
 
 let instance = null;
 
@@ -31,6 +19,18 @@ class AdapterFactory extends EventEmitter {
     super();
     if (instance == null) {
       instance = this;
+      this.adapters = [];
+      configuredAdapters.forEach(a => {
+        try {
+          const { path, name } = a;
+          const adapter = require(`${adapterPathPrefix}${path}`);
+          this.adapters.push({ adapter, name });
+        } catch (e) {
+          Logger.error('[mcs-adapter-factory] Could not add configured adapter', a, e);
+        }
+      });
+
+      Logger.debug('[mcs-adapter-factory] Configured media server adapters', this.adapters, this.adapters.map(a => a.name));
     }
     return instance;
   }
@@ -45,10 +45,10 @@ class AdapterFactory extends EventEmitter {
 
   findAdapter (adapterName) {
     let adapter = null;
-    const adapterObj = adapters.find(a => a.name === adapterName);
+    const adapterObj = this.adapters.find(a => a.name === adapterName);
     if (adapterObj) {
-      const constructor = adapterObj.adapter;
-      adapter = new constructor(Balancer);
+      const aConstructor = adapterObj.adapter;
+      adapter = new aConstructor(Balancer);
     }
 
     return adapter;

--- a/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -12,6 +12,8 @@ const rid = require('readable-id');
 
 const FREESWITCH_IP = config.get('freeswitch').ip;
 const FREESWITCH_PORT = config.get('freeswitch').port;
+const SDPMedia = require('../../model/sdp-media');
+
 
 let instance = null;
 
@@ -28,6 +30,36 @@ module.exports = class Freeswitch extends EventEmitter {
     }
 
     return instance;
+  }
+  negotiate (roomId, userId, mediaSessionId, descriptor, type, options) {
+    let media;
+    try {
+      switch (type) {
+        case C.MEDIA_TYPE.RTP:
+        case C.MEDIA_TYPE.WEBRTC:
+          return this._negotiateSDPEndpoint(roomId, userId, mediaSessionId, descriptor, type, options);
+          break;
+        default:
+          throw(this._handleError(ERRORS[40107]));
+      }
+    } catch (err) {
+      throw(this._handleError(err));
+    }
+  }
+
+  async _negotiateSDPEndpoint (roomId, userId, mediaSessionId, descriptor, type, options) {
+    let mediaElement, host;
+
+    Logger.debug("[mcs-kurento-adapter] Negotiating SDP endpoint for", userId, "at", roomId);
+    try {
+      ({ mediaElement, host } = await this.createMediaElement(roomId, type, options));
+      const answer = await this.processOffer(mediaElement, descriptor, options);
+      const media = new SDPMedia(roomId, userId, mediaSessionId, descriptor, answer, type, this, mediaElement, host, options);
+      media.trackMedia();
+      return [media];
+    } catch (err) {
+      throw(this._handleError(err));
+    }
   }
 
   async createMediaElement (roomId, type, params) {

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -430,12 +430,7 @@ module.exports = class Kurento extends EventEmitter {
     });
   }
 
-  async disconnect (sourceId, sinkId, type) {
-    const source = this._mediaElements[sourceId];
-    const sink = this._mediaElements[sinkId];
-    // TODO temporarily disabled disconnect because of transposing
-    return;
-
+  async _disconnect (source, sink, type) {
     return new Promise((resolve, reject) => {
       if (source == null || sink == null) {
         return reject(this._handleError(ERRORS[40101]));
@@ -460,7 +455,7 @@ module.exports = class Kurento extends EventEmitter {
             });
 
           case 'VIDEO':
-            source.disconnect(sink, (error) => {
+            source.disconnect(sink, 'VIDEO', (error) => {
               if (error) {
                 return reject(this._handleError(error));
               }
@@ -477,6 +472,34 @@ module.exports = class Kurento extends EventEmitter {
       }
     });
   }
+
+  disconnect (sourceId, sinkId, type) {
+    const source = this._mediaElements[sourceId];
+    const sink = this._mediaElements[sinkId];
+
+    return new Promise(async (resolve, reject) => {
+      if (source == null || sink == null) {
+        return reject(this._handleError(ERRORS[40101]));
+      }
+
+      const isTransposed = source.host.id !== sink.host.id;
+
+      try {
+        if (isTransposed) {
+          const transposedSink = sink.pipeline.transposers[source.host.id+source.id]
+          await this._disconnect(transposedSink, sink, type);
+          resolve();
+        } else {
+          await this._disconnect(source, sink, type);
+          resolve();
+        }
+      }
+      catch (error) {
+        return reject(this._handleError(error));
+      }
+    });
+  }
+
 
   stop (room, type, elementId) {
     return new Promise(async (resolve, reject) => {

--- a/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -11,10 +11,12 @@ const KMS_CLIENT = require('kurento-client');
 const SdpWrapper = require('../../utils/sdp-wrapper');
 const Queue = require('kue');
 const GLOBAL_EVENT_EMITTER = require('../../utils/emitter');
+const SDPMedia = require('../../model/sdp-media');
+const LOG_PREFIX = "[mcs-kurento-adapter]";
 
 let instance = null;
 
-module.exports = class MediaServer extends EventEmitter {
+module.exports = class Kurento extends EventEmitter {
   constructor(balancer) {
     if (!instance){
       super();
@@ -78,7 +80,7 @@ module.exports = class MediaServer extends EventEmitter {
         const host = this.balancer.retrieveHost(hostId);
         const { client } = host;
         if (this._mediaPipelines[roomId] && this._mediaPipelines[roomId][host.id]) {
-          Logger.info('[mcs-media] Pipeline for', roomId, 'at host', host.id, ' already exists.');
+          Logger.info(LOG_PREFIX, 'Pipeline for', roomId, 'at host', host.id, ' already exists.');
           return resolve()
         } else {
           const pipeline = await this._createMediaPipeline(hostId);
@@ -88,7 +90,7 @@ module.exports = class MediaServer extends EventEmitter {
             this._mediaPipelines[roomId] = {};
           }
           this._mediaPipelines[roomId][host.id] = pipeline;
-          Logger.info("[mcs-media] Created pipeline at room", roomId, "with host", hostId, host.id, pipeline.id);
+          Logger.info(LOG_PREFIX, "Created pipeline at room", roomId, "with host", hostId, host.id, pipeline.id);
           pipeline.activeElements = 0;
 
           return resolve();
@@ -115,7 +117,7 @@ module.exports = class MediaServer extends EventEmitter {
   _releasePipeline (room, hostId) {
     return new Promise((resolve, reject) => {
       try {
-        Logger.debug("[mcs-media] Releasing room", room, "pipeline at host", hostId);
+        Logger.debug(LOG_PREFIX, "Releasing room", room, "pipeline at host", hostId);
         const pipeline = this._mediaPipelines[room][hostId];
         if (pipeline && typeof pipeline.release === 'function') {
           pipeline.release((error) => {
@@ -140,7 +142,7 @@ module.exports = class MediaServer extends EventEmitter {
           if (error) {
             return reject(this._handleError(error));
           }
-          Logger.info("[mcs-media] Created [" + type + "] media element: " + mediaElement.id);
+          Logger.info(LOG_PREFIX, "Created [" + type + "] media element: " + mediaElement.id);
           mediaElement.host = pipeline.host;
           mediaElement.pipeline = pipeline;
           mediaElement.transposers = {};
@@ -154,6 +156,80 @@ module.exports = class MediaServer extends EventEmitter {
     });
   }
 
+  negotiate (roomId, userId, mediaSessionId, descriptor, type, options) {
+    let media;
+    try {
+      switch (type) {
+        case C.MEDIA_TYPE.RTP:
+          return this._negotiateSDPEndpoint(roomId, userId, mediaSessionId, descriptor, type, options);
+          break;
+        case C.MEDIA_TYPE.WEBRTC:
+          return this._negotiateWebRTCEndpoint(roomId, userId, mediaSessionId, descriptor, type, options);
+          break;
+        case C.MEDIA_TYPE.RECORDING:
+          return this._negotiateRecordingEndpoint(roomId, userId, mediaSessionId, descriptor, type, options);
+          break;
+        case C.MEDIA_TYPE.URI:
+          // TODO no-op
+          break;
+        default:
+          throw(this._handleError(ERRORS[40107]));
+      }
+    } catch (err) {
+      throw(this._handleError(err));
+    }
+  }
+
+  _negotiateSDPEndpoint (roomId, userId, mediaSessionId, descriptor, type, options) {
+    let mediaElement, host;
+
+    Logger.debug(LOG_PREFIX, "Negotiating SDP endpoint for", userId, "at", roomId);
+    try {
+      // We strip the SDP into media units of the same type because Kurento can't handle
+      // bundling other than audio + video
+      const partialDescriptors = SdpWrapper.getPartialDescriptions(descriptor);
+      let medias = []
+      const negotiationProcedures = partialDescriptors.map(d => {
+        return new Promise(async (resolve, reject) => {
+          try {
+            ({ mediaElement, host } = await this.createMediaElement(roomId, type, options));
+            const answer = await this.processOffer(mediaElement, d);
+            const media = new SDPMedia(roomId, userId, mediaSessionId, descriptor, answer, type, this, mediaElement, host, options);
+            media.trackMedia();
+            medias.push(media);
+            resolve();
+          } catch (err) {
+            reject(this._handleError(err));
+          }
+        });
+      });
+
+      return Promise.all(negotiationProcedures).then(() => {
+        return medias;
+      });
+    } catch (err) {
+      throw(this._handleError(err));
+    }
+  }
+
+  async _negotiateWebRTCEndpoint (roomId, userId, mediaSessionId, descriptor, type, options) {
+    try {
+      const medias = await this._negotiateSDPEndpoint(roomId, userId, mediaSessionId, descriptor, type, options);
+      medias.forEach(m => {
+        if (m.type === C.MEDIA_TYPE.WEBRTC) {
+          this.gatherCandidates(m.adapterElementId);
+        }
+      });
+      return medias;
+    } catch (err) {
+      throw(this._handleError(err));
+    }
+  }
+
+  _negotiateRecordingEndpoint (roomId, userId, mediaSessionId, descriptor, type, options) {
+    // no-op
+  }
+
   createMediaElement (roomId, type, options = {}) {
     options = options || {};
     return new Promise(async (resolve, reject) => {
@@ -165,14 +241,14 @@ module.exports = class MediaServer extends EventEmitter {
         }).save().priority('high');
 
         const onPipelineCreated = async (cjob) => {
-            const pipeline = this._mediaPipelines[roomId][host.id];
-            const mediaElement = await this._createElement(pipeline, type, options);
-            if (typeof mediaElement.setKeyframeInterval === 'function' && options.keyframeInterval) {
-              Logger.debug("[mcs-media] Creating element with keyframe interval set to", options.keyframeInterval);
-              mediaElement.setKeyframeInterval(options.keyframeInterval);
-            }
-            this._mediaPipelines[roomId][host.id].activeElements++;
-            return resolve({ mediaElement: mediaElement.id , host });
+          const pipeline = this._mediaPipelines[roomId][host.id];
+          const mediaElement = await this._createElement(pipeline, type, options);
+          if (typeof mediaElement.setKeyframeInterval === 'function' && options.keyframeInterval) {
+            Logger.debug(LOG_PREFIX, "Creating element with keyframe interval set to", options.keyframeInterval);
+            mediaElement.setKeyframeInterval(options.keyframeInterval);
+          }
+          this._mediaPipelines[roomId][host.id].activeElements++;
+          return resolve({ mediaElement: mediaElement.id , host });
         };
 
         job.on('complete', onPipelineCreated).on('failed', (e) => {
@@ -231,7 +307,7 @@ module.exports = class MediaServer extends EventEmitter {
       try {
         const source = this._mediaElements[sourceId];
         const sink = this._mediaElements[sinkId];
-        Logger.info("[mcs-media] Transposing from", source.id, "| host", source.host.id,  "to", sink.id, "| host", sink.host.id);
+        Logger.info(LOG_PREFIX, "Transposing from", source.id, "| host", source.host.id,  "to", sink.id, "| host", sink.host.id);
         let sourceTransposer, sinkTransposer, sourceOffer, sinkAnswer;
 
         sourceTransposer = source.transposers[sink.host.id];
@@ -239,7 +315,7 @@ module.exports = class MediaServer extends EventEmitter {
         if (sourceTransposer == null) {
           source.transposers[sink.host.id] = {};
           this._transposingQueue.push(source.host.id+source.id+sink.host.id);
-          Logger.info("[mcs-media] Source transposer for", source.id, "to host", sink.host.id, "not found");
+          Logger.info(LOG_PREFIX, "Source transposer for", source.id, "to host", sink.host.id, "not found");
           sourceTransposer = await this._createElement(source.pipeline, C.MEDIA_TYPE.RTP);
           source.transposers[sink.host.id] = sourceTransposer;
           sourceOffer = await this.generateOffer(sourceTransposer.id);
@@ -248,7 +324,7 @@ module.exports = class MediaServer extends EventEmitter {
           sourceOffer = SdpWrapper.convertToString(filteredOffer);
           this.balancer.incrementHostStreams(source.host.id, 'video');
 
-          Logger.info("[mcs-media] Sink transposer for pipeline", sink.pipeline.id, "for host", source.id, source.host.id, "not found");
+          Logger.info(LOG_PREFIX, "Sink transposer for pipeline", sink.pipeline.id, "for host", source.id, source.host.id, "not found");
           sink.pipeline.transposers[source.host.id+source.id] = sinkTransposer = await this._createElement(sink.pipeline, C.MEDIA_TYPE.RTP);
           sinkAnswer = await this.processOffer(sinkTransposer.id, SdpWrapper.nonPureReplaceServerIpv4(sourceOffer, source.host.ip));
           await this.processAnswer(sourceTransposer.id, SdpWrapper.nonPureReplaceServerIpv4(sinkAnswer, sink.host.ip));
@@ -405,7 +481,7 @@ module.exports = class MediaServer extends EventEmitter {
   stop (room, type, elementId) {
     return new Promise(async (resolve, reject) => {
       try {
-        Logger.info("[mcs-media] Releasing endpoint", elementId, "from room", room);
+        Logger.info(LOG_PREFIX, "Releasing endpoint", elementId, "from room", room);
         const mediaElement = this._mediaElements[elementId];
 
         if (type === 'RecorderEndpoint') {
@@ -422,7 +498,7 @@ module.exports = class MediaServer extends EventEmitter {
             Object.keys(mediaElement.transposers).forEach(t => {
               setTimeout(() => {
                 mediaElement.transposers[t].release();
-                Logger.debug("[mcs-media] Releasing transposer", t, "for", elementId);
+                Logger.debug(LOG_PREFIX, "Releasing transposer", t, "for", elementId);
                 this.balancer.decrementHostStreams(hostId, 'video');
               }, 0);
             });
@@ -453,7 +529,7 @@ module.exports = class MediaServer extends EventEmitter {
               if (pipeline) {
                 pipeline.activeElements--;
 
-                Logger.info("[mcs-media] Pipeline has a total of", pipeline.activeElements, "active elements");
+                Logger.info(LOG_PREFIX, "Pipeline has a total of", pipeline.activeElements, "active elements");
                 if (pipeline.activeElements <= 0) {
                   await this._releasePipeline(room, hostId);
                 }
@@ -463,7 +539,7 @@ module.exports = class MediaServer extends EventEmitter {
           }
         }
         else {
-          Logger.warn("[mcs-media] Media element", elementId, "could not be found to stop");
+          Logger.warn(LOG_PREFIX, "Media element", elementId, "could not be found to stop");
           return resolve();
         }
       }
@@ -483,7 +559,7 @@ module.exports = class MediaServer extends EventEmitter {
             if (error) {
               return reject(this._handleError(error));
             }
-            Logger.trace("[mcs-media] Added ICE candidate for => ", elementId, candidate);
+            Logger.trace(LOG_PREFIX, "Added ICE candidate for => ", elementId, candidate);
             return resolve();
           });
         }
@@ -498,7 +574,7 @@ module.exports = class MediaServer extends EventEmitter {
   }
 
   gatherCandidates (elementId) {
-    Logger.info('[mcs-media] Gathering ICE candidates for ' + elementId);
+    Logger.info(LOG_PREFIX, 'Gathering ICE candidates for ' + elementId);
     const mediaElement = this._mediaElements[elementId];
 
     return new Promise((resolve, reject) => {
@@ -510,7 +586,7 @@ module.exports = class MediaServer extends EventEmitter {
           if (error) {
             return reject(this._handleError(error));
           }
-          Logger.info('[mcs-media] Triggered ICE gathering for ' + elementId);
+          Logger.info(LOG_PREFIX, 'Triggered ICE gathering for ' + elementId);
           return resolve();
         });
       }
@@ -527,7 +603,7 @@ module.exports = class MediaServer extends EventEmitter {
       mediaElement.setMinVideoRecvBandwidth(min);
       mediaElement.setMaxVideoRecvBandwidth(max);
     } else {
-      return ("[mcs-media] There is no element " + elementId);
+      return (LOG_PREFIX, "There is no element " + elementId);
     }
   }
 
@@ -538,7 +614,7 @@ module.exports = class MediaServer extends EventEmitter {
       mediaElement.setMinVideoSendBandwidth(min);
       mediaElement.setMaxVideoSendBandwidth(max);
     } else {
-      return ("[mcs-media] There is no element " + elementId );
+      return (LOG_PREFIX, "There is no element " + elementId );
     }
   }
 
@@ -549,14 +625,14 @@ module.exports = class MediaServer extends EventEmitter {
       mediaElement.setMinOutputBitrate(min);
       mediaElement.setMaxOutputBitrate(max);
     } else {
-      return ("[mcs-media] There is no element " + elementId);
+      return (LOG_PREFIX, "There is no element " + elementId);
     }
   }
 
   processOffer (elementId, sdpOffer, params = {})  {
     const { replaceIp } = params;
     const mediaElement = this._mediaElements[elementId];
-    Logger.trace("[mcs-media] Processing offer", sdpOffer, "for element", elementId);
+    Logger.trace(LOG_PREFIX, "Processing", elementId, "offer", sdpOffer);
 
     return new Promise((resolve, reject) => {
       try {
@@ -565,10 +641,10 @@ module.exports = class MediaServer extends EventEmitter {
             if (error) {
               return reject(this._handleError(error));
             }
-          if (replaceIp) {
-            answer = answer.replace(/(IP4\s[0-9.]*)/g, 'IP4 ' + mediaElement.host.ip);
+            if (replaceIp) {
+              answer = answer.replace(/(IP4\s[0-9.]*)/g, 'IP4 ' + mediaElement.host.ip);
 
-          }
+            }
             return resolve(answer);
           });
         }
@@ -666,7 +742,7 @@ module.exports = class MediaServer extends EventEmitter {
     let event = {};
     try {
       if (mediaElement) {
-        Logger.debug('[mcs-media] Adding media state listener [' + eventTag + '] for ' + elementId);
+        Logger.debug(LOG_PREFIX, 'Adding media state listener [' + eventTag + '] for ' + elementId);
         mediaElement.on(eventTag, (e) => {
           switch (eventTag) {
             case C.EVENT.MEDIA_STATE.ICE:
@@ -719,9 +795,7 @@ module.exports = class MediaServer extends EventEmitter {
     let { message: oldMessage , code, stack } = err;
     let message;
 
-    if (err.stack) {
-      Logger.trace('[mcs-media] Error stack', err.stack);
-    }
+    Logger.trace(LOG_PREFIX, 'Error stack', err);
 
     if (code && code >= C.ERROR.MIN_CODE && code <= C.ERROR.MAX_CODE) {
       return err;
@@ -733,11 +807,11 @@ module.exports = class MediaServer extends EventEmitter {
       switch (oldMessage) {
         case "Request has timed out":
           ({ code, message }  = C.ERROR.MEDIA_SERVER_REQUEST_TIMEOUT);
-        break;
+          break;
 
         case "Connection error":
           ({ code, message } = C.ERROR.CONNECTION_ERROR);
-        break;
+          break;
 
         default:
           ({ code, message } = C.ERROR.MEDIA_SERVER_GENERIC_ERROR);
@@ -757,7 +831,7 @@ module.exports = class MediaServer extends EventEmitter {
     err.details = oldMessage;
     err.stack = stack
 
-    Logger.debug('[mcs-media] Media Server returned an', err.code, err.message);
+    Logger.debug(LOG_PREFIX, 'Media Server returned an', err.code, err.message);
     return err;
   }
 };

--- a/lib/mcs-core/lib/constants/constants.js
+++ b/lib/mcs-core/lib/constants/constants.js
@@ -24,7 +24,18 @@ exports.MEDIA_TYPE = {}
 exports.MEDIA_TYPE.WEBRTC = "WebRtcEndpoint"
 exports.MEDIA_TYPE.RTP = "RtpEndpoint"
 exports.MEDIA_TYPE.URI = "PlayerEndpoint"
-exports.MEDIA_TYPE.RECORDING = "RecorderEndpoint";
+exports.MEDIA_TYPE.RECORDING = "RecorderEndpoint"
+
+exports.MEDIA_PROFILE = {}
+exports.MEDIA_PROFILE.MAIN = 'main'
+exports.MEDIA_PROFILE.CONTENT = 'content'
+exports.MEDIA_PROFILE.AUDIO = 'audio'
+
+exports.CONNECTION_TYPE = {}
+exports.CONNECTION_TYPE.VIDEO = 'VIDEO'
+exports.CONNECTION_TYPE.AUDIO = 'AUDIO'
+exports.CONNECTION_TYPE.CONTENT = 'VIDEO'
+exports.CONNECTION_TYPE.ALL = 'ALL'
 
 // Media server state changes
 exports.EMAP = {

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -294,6 +294,18 @@ const MR = class MCSRouter {
   setupClient(client) {
     const id = clientId++;
     this.clients[id] = client;
+    client.trackingId = id;
+
+    client.on('close', () => {
+      this._removeClientFromEventMap(client);
+      this._removeClientFromTracking(client);
+    });
+
+    client.on('error', () => {
+      this._removeClientFromEventMap(client);
+      this._removeClientFromTracking(client);
+    });
+
     client.on('join', async (args) =>  {
       let transactionId;
       try {
@@ -562,6 +574,19 @@ const MR = class MCSRouter {
 
   _removeFromClientEventMap (identifier, eventName) {
     this.clientEventMap = this.clientEventMap.filter(c => c.identifier !== identifier && c.eventName !== eventName);
+  }
+
+  _removeClientFromEventMap (client) {
+    Logger.trace('[mcs-router]', "Removing client", client.trackingId, "from event map");
+    this.clientEventMap = this.clientEventMap.filter(c => c.trackingId == client.trackingId);
+  }
+
+  _removeClientFromTracking (client) {
+    const { trackingId } = client;
+    if (trackingId && this.clients[trackingId]) {
+      Logger.trace('[mcs-router]', "Removing client", trackingId, "from tracking");
+      delete this.clients[trackingId];
+    }
   }
 
   _getClientToDispatch (identifier, eventName) {

--- a/lib/mcs-core/lib/media/mcs-message-router.js
+++ b/lib/mcs-core/lib/media/mcs-message-router.js
@@ -130,8 +130,8 @@ const MR = class MCSRouter {
   }
 
   async connect (args) {
-    const { source_id, sink_ids, type } = args;
     try {
+      const { source_id, sink_ids, type } = args;
       let cPromises = sink_ids.map((sink) => {
         this._mediaController.connect(source_id, sink, type);
       });
@@ -143,15 +143,22 @@ const MR = class MCSRouter {
       });
     }
     catch (error) {
-      throw (this._handleError(error, 'connect', { source_id, sink_ids, type }));
+      throw (this._handleError(error, 'connect', { ...args }));
     }
   }
 
-  async disconnect (source, sink, type) {
+  async disconnect (args) {
     try {
-      await this._mediaController.disconnect(source, sink, type);
-      //await this._mediaController.disconnect(source, sink, type);
-      return ;
+      const { source_id, sink_ids, type } = args;
+      let dcPromises = sink_ids.map((sink) => {
+        this._mediaController.disconnect(source_id, sink, type);
+      });
+
+      await Promise.all(dcPromises).then(() => {
+        return;
+      }).catch((err) => {
+        throw (this._handleError(err, 'disconnect', { source_id, sink_ids, type }));
+      });
     }
     catch (error) {
       throw (this._handleError(error, 'disconnect', { source, sink, type }));
@@ -410,7 +417,7 @@ const MR = class MCSRouter {
       try {
         ({ transactionId, source_id, sink_ids } = args);
         await this.disconnect(args);
-        client.disconnected(sourceId, sink_ids, { transactionId });
+        client.disconnected(source_id, sink_ids, { transactionId });
       } catch (e) {
         this._notifyMethodError(client, e, transactionId);
       }

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -362,7 +362,7 @@ module.exports = class MediaController {
     let user;
     Logger.info("[mcs-controller] Creating a new", type, "user at room", roomId);
 
-    user  = new User(roomId, type);
+    user  = new User(roomId, type, params);
 
     if(this._users[user.id] == null) {
       this._users[user.id] = user;

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -285,11 +285,11 @@ module.exports = class MediaController {
   disconnect (sourceId, sinkId, type) {
     return new Promise(async (resolve, reject) => {
       try {
-        Logger.info("[mcs-controller] Disconnect", sourceId, "to", sinkId, "with type", type);
+        Logger.info("[mcs-controller] Disconnect", sourceId, "from", sinkId, "with type", type);
         const sourceSession = this.getMediaSession(sourceId);
         const sinkSession = this.getMediaSession(sinkId);
 
-        await sourceSession.disconnect(sinkSession._mediaElement, type);
+        await sourceSession.disconnect(sinkSession, type);
         return resolve();
       }
       catch (err) {

--- a/lib/mcs-core/lib/media/media-controller.js
+++ b/lib/mcs-core/lib/media/media-controller.js
@@ -8,8 +8,10 @@ const Room = require('../model/room');
 const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
 const { handleError } = require('../utils/util');
 const LOG_PREFIX = "[mcs-controller]";
+const Balancer = require('./balancer');
 
-/* PUBLIC ELEMENTS */
+// Fire that balancer
+Balancer.upstartHosts();
 
 let instance = null;
 

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -156,14 +156,62 @@ module.exports = class MediaSession {
 
   async disconnect (sink, type = 'ALL') {
     try {
-      Logger.info("[mcs-media-session] Dis-connecting " + this._mediaElement + " => " + sinkId);
-      await this._MediaServer.disconnect(this._mediaElement, sinkId, type);
-      return Promise.resolve();
+      // Disconnect this media session to sinks of the appropriate type
+      // in the future, it'd also be nice to be able to connect children media of a session
+      switch (type ) {
+        case C.MEDIA_PROFILE.CONTENT:
+          await this._disconnectContent(sink);
+          break;
+        case C.MEDIA_PROFILE.AUDIO:
+          await this._disconnectAudio(sink);
+          break;
+        case C.MEDIA_PROFILE.VIDEO:
+          await this._disconnectVideo(sink);
+          break;
+        default:
+          await this._disconnectEverything(sink);
+      }
+      return;
     }
     catch (err) {
-      err = this._handleError(err);
-      return Promise.reject(err);
+      throw (this._handleError(err));
     }
+  }
+
+  async _disconnect (sink, sourceMediaId, mediaProfile, connectionType) {
+    const sourceMedia = sourceMediaId? sourceMediaId : this.medias.find(m => m._mediaProfile === mediaProfile);
+    const sinkMedias = sink.medias.filter(m => (m._mediaProfile === mediaProfile || mediaProfile === C.MEDIA_PROFILE.ALL));
+    if (sourceMedia && sinkMedias.length > 0) {
+      sinkMedias.forEach(sm => {
+        Logger.trace("[mcs-media-session] Adapter elements to be disconnected", sourceMedia.adapterElementId, "=>", sm.adapterElementId);
+        try {
+          return sourceMedia.adapter.disconnect(
+            sourceMedia.adapterElementId,
+            sm.adapterElementId,
+            connectionType,
+          );
+        } catch (err) {
+          throw (this._handleError(err));
+        }
+      });
+    }
+  }
+
+  _disconnectContent (sink, sourceMediaId = null) {
+    return this._disconnect(sink, sourceMediaId, C.MEDIA_PROFILE.CONTENT, C.CONNECTION_TYPE.VIDEO);
+  }
+
+  _disconnectAudio (sink, sourceMediaId = null) {
+    return this._disconnect(sink, sourceMediaId, C.MEDIA_PROFILE.AUDIO, C.CONNECTION_TYPE.AUDIO);
+  }
+
+  _disconnectVideo (sink, sourceMediaId = null) {
+    return this._disconnect(sink, sourceMediaId, C.MEDIA_PROFILE.VIDEO, C.CONNECTION_TYPE.VIDEO);
+  }
+
+  _disconnectEverything (sink, sourceMediaId = null) {
+    // me not that kind of orc
+    return this._disconnect(sink, sourceMediaId, C.MEDIA_PROFILE.ALL, C.CONNECTION_TYPE.ALL);
   }
 
   sessionStarted () {

--- a/lib/mcs-core/lib/model/media-session.js
+++ b/lib/mcs-core/lib/model/media-session.js
@@ -9,16 +9,12 @@ const C = require('../constants/constants');
 const rid = require('readable-id');
 const Kurento = require('../adapters/kurento/kurento');
 const Freeswitch = require('../adapters/freeswitch/freeswitch');
-const Balancer = require('../media/balancer');
 const config = require('config');
 const Logger = require('../utils/logger');
-const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
 const AdapterFactory = require('../adapters/adapter-factory');
 const { handleError } = require('../utils/util');
 
 const LOG_PREFIX = "[mcs-media-session]";
-
-Balancer.upstartHosts();
 
 const isComposedAdapter = adapter => {
   if (typeof adapter === 'object') {
@@ -40,8 +36,6 @@ module.exports = class MediaSession {
     this.id = rid();
     this.roomId = room;
     this.userId = user;
-    this.balancer = Balancer;
-    this.emitter = GLOBAL_EVENT_EMITTER;
     this._options = options;
     // State indicator of this session. Might be STOPPED, STARTING or STARTED
     this._status = C.STATUS.STOPPED;
@@ -73,11 +67,6 @@ module.exports = class MediaSession {
     }
     this._muted = false;
     this._mediaProfile = options.mediaProfile? options.mediaProfile : 'main';
-    // API event buffers for this media session
-    this.eventQueue = [];
-    this.outboundIceQueue = [];
-    this._mediaStateSubscription = false;
-    this._iceSubscription = false;
   }
 
   async start () {
@@ -85,77 +74,15 @@ module.exports = class MediaSession {
     return;
   }
 
-  async _upstartMediaElement (adapter, element) {
-    adapter.on(C.EVENT.MEDIA_STATE.MEDIA_EVENT+element, this._dispatchMediaStateEvent.bind(this));
-    adapter.on(C.EVENT.MEDIA_STATE.ICE+element, this._dispatchIceCandidate.bind(this));
-
-    adapter.trackMediaState(element, this._type);
-
-    const notifyHostOffline = (hostId) => {
-      if ((this.videoHost && this.videoHost.id === hostId) || (this.audioHost && this.audioHost.id === hostId)) {
-        let event = {};
-        event.state = { name: C.EVENT.MEDIA_SERVER_OFFLINE, details: 'offline' };
-        event.mediaId = this.id;
-        this.emitter.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, event);
-
-        this.balancer.removeListener(C.EVENT.MEDIA_SERVER_OFFLINE, notifyHostOffline);
-      }
-    };
-
-    const notifyHostOnline = (hostId) => {
-      if ((this.videoHost && this.videoHost.id === hostId) || (this.audioHost && this.audioHost.id === hostId)) {
-        let event = {};
-        event.state = { name : C.EVENT.MEDIA_SERVER_ONLINE, details: 'online' };
-        event.mediaId = this.id;
-        this.emitter.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, event);
-      }
-    };
-
-    this.balancer.on(C.EVENT.MEDIA_SERVER_OFFLINE, notifyHostOffline);
-    this.balancer.on(C.EVENT.MEDIA_SERVER_ONLINE, notifyHostOnline);
-
-    this.balancer.on(C.EVENT.MEDIA_SERVER_ONLINE, () => {
-      let event = {};
-      event.state = C.EVENT.MEDIA_SERVER_ONLINE;
-      event.mediaId = this.id;
-      this.emitter.emit(C.EVENT.SERVER_STATE, event);
-    });
-
-    Logger.info("[mcs-media-session] New media session", this.id, "in room", this.roomId, "started with media server endpoint", element);
-  }
-
-  async stop () {
+  stop () {
     if (this._status === C.STATUS.STARTED || this._states === C.STATUS.STARTING) {
       this._status = C.STATUS.STOPPING;
       try {
-        const {
-          videoAdapter,
-          audioAdapter,
-          contentAdapter
-        } = this._adapters;
-
-        if (this.videoMediaElement) {
-          await videoAdapter.stop(this.roomId, this._type, this.videoMediaElement);
-          if (this._answer && this._answer.hasAvailableVideoCodec()) {
-            this.balancer.decrementHostStreams(this.videoHost.id, 'video');
-          }
-        }
-
-        if (this.audioMediaElement) {
-          await audioAdapter.stop(this.roomId, this._type, this.audioMediaElement);
-          if (this._answer && this._answer.hasAvailableAudioCodec()) {
-            this.balancer.decrementHostStreams(this.videoHost.id, 'audio');
-          }
-        }
-
-        if (this.contentMediaElement) {
-          await contentAdapter.stop(this.roomId, this._type, this.contentMediaElement);
-        }
+        this.medias.forEach(async m => {
+          await m.stop();
+        });
 
         this._status = C.STATUS.STOPPED;
-        Logger.info("[mcs-media-session] Session", this.id, "stopped with status", this._status);
-        this.emitter.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.id });
-
         return Promise.resolve();
       }
       catch (err) {
@@ -169,41 +96,65 @@ module.exports = class MediaSession {
 
   async connect (sink, type = 'ALL') {
     try {
-      const {
-        videoAdapter,
-        audioAdapter,
-        contentAdapter
-      } = this._adapters;
-
-      let adapter, sourceElement, sinkElement;
-      Logger.info("[mcs-media-session] Connecting", this.id, "=>", sink.id, "with type", type);
-
-      if (type === 'CONTENT') {
-        adapter = contentAdapter;
-        sourceElement = this.contentMediaElement;
-        sinkElement = sink.videoMediaElement;
-        type = 'VIDEO';
-      } else if (type === 'AUDIO') {
-        adapter = audioAdapter;
-        sourceElement = this.audioMediaElement;
-        sinkElement = sink.audioMediaElement;
-      } else {
-        adapter = videoAdapter;
-        sourceElement = this.videoMediaElement;
-        sinkElement = sink.videoMediaElement;
+      // Connect this media session to sinks of the appropriate type
+      // in the future, it'd also be nice to be able to connect children media of a session
+      switch (type ) {
+        case C.MEDIA_PROFILE.CONTENT:
+          await this._connectContent(sink);
+          break;
+        case C.MEDIA_PROFILE.AUDIO:
+          await this._connectAudio(sink);
+          break;
+        case C.MEDIA_PROFILE.VIDEO:
+          await this._connectVideo(sink);
+          break;
+        default:
+          await this._connectEverything(sink);
       }
-
-      Logger.debug("[mcs-media-session] Adapter elements to be connected", sourceElement, "=>", sinkElement);
-      await adapter.connect(sourceElement, sinkElement, type);
       return;
     }
     catch (err) {
-      err = this._handleError(err);
-      throw err;
+      throw (this._handleError(err));
     }
   }
 
-  async disconnect (sinkId, type = 'ALL') {
+  async _connect (sink, sourceMediaId, mediaProfile, connectionType) {
+    const sourceMedia = sourceMediaId? sourceMediaId : this.medias.find(m => m._mediaProfile === mediaProfile);
+    const sinkMedias = sink.medias.filter(m => (m._mediaProfile === mediaProfile || mediaProfile === C.MEDIA_PROFILE.ALL));
+    if (sourceMedia && sinkMedias.length > 0) {
+      sinkMedias.forEach(sm => {
+        Logger.trace("[mcs-media-session] Adapter elements to be connected", sourceMedia.adapterElementId, "=>", sm.adapterElementId);
+        try {
+          return sourceMedia.adapter.connect(
+            sourceMedia.adapterElementId,
+            sm.adapterElementId,
+            connectionType,
+          );
+        } catch (err) {
+          throw (this._handleError(err));
+        }
+      });
+    }
+  }
+
+  _connectContent (sink, sourceMediaId = null) {
+    return this._connect(sink, sourceMediaId, C.MEDIA_PROFILE.CONTENT, C.CONNECTION_TYPE.VIDEO);
+  }
+
+  _connectAudio (sink, sourceMediaId = null) {
+    return this._connect(sink, sourceMediaId, C.MEDIA_PROFILE.AUDIO, C.CONNECTION_TYPE.AUDIO);
+  }
+
+  _connectVideo (sink, sourceMediaId = null) {
+    return this._connect(sink, sourceMediaId, C.MEDIA_PROFILE.VIDEO, C.CONNECTION_TYPE.VIDEO);
+  }
+
+  _connectEverything (sink, sourceMediaId = null) {
+    // me not that kind of orc
+    return this._connect(sink, sourceMediaId, C.MEDIA_PROFILE.ALL, C.CONNECTION_TYPE.ALL);
+  }
+
+  async disconnect (sink, type = 'ALL') {
     try {
       Logger.info("[mcs-media-session] Dis-connecting " + this._mediaElement + " => " + sinkId);
       await this._MediaServer.disconnect(this._mediaElement, sinkId, type);
@@ -222,66 +173,28 @@ module.exports = class MediaSession {
     }
   }
 
-  onEvent (eventName) {
-    switch (eventName) {
-      case C.EVENT.MEDIA_STATE.MEDIA_EVENT:
-        this._mediaStateSubscription = true;
-        this._flushMediaStateEvents();
-        break;
-      case C.EVENT.MEDIA_STATE.ICE:
-        this._iceSubscription = true;
-        this._flushIceEvents();
-        break;
-      default: Logger.trace("[mcs-media-session] Unknown event subscription", eventName);
+  onEvent (eventName, mediaId) {
+    // Media specific event listener
+    if (mediaId) {
+      const media = this.medias.find(m => m.id === mediaId);
+      if (media) {
+        media.onEvent(eventName);
+      }
+      return;
     }
 
-  }
-
-  _dispatchMediaStateEvent (event) {
-    if (!this._mediaStateSubscription) {
-      Logger.debug("[mcs-media-session] Media session", this.id, "queuing event", { mediaId: this.id, ...event });
-      this.eventQueue.push(event);
-    }
-    else {
-      Logger.trace("[mcs-media-session] Dispatching", event);
-      this.emitter.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, { mediaId: this.id, ...event });
-    }
-  }
-
-  _dispatchIceCandidate (event) {
-    if (!this._iceSubscription) {
-      Logger.debug("[mcs-media-session] Media session", this.id, "queuing event", event);
-      this.outboundIceQueue.push({ mediaId: this.id, ...event});
-    }
-    else {
-      Logger.trace("[mcs-media-session] Dispatching ICE", event);
-      this.emitter.emit(C.EVENT.MEDIA_STATE.ICE, { mediaId: this.id, ...event });
-    }
-  }
-
-  _flushMediaStateEvents () {
-    Logger.debug("[mcs-media-session] Flushing session", this.id, "media state queue");
-
-    while (this.eventQueue.length) {
-      const event = this.eventQueue.shift();
-      Logger.trace("[mcs-media-session] Dispatching queued media state event", event);
-      this.emitter.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, event);
-    }
-  }
-
-  _flushIceEvents () {
-    Logger.debug("[mcs-media-session] Flushing session", this.id, "ICE queue", this.outboundIceQueue);
-
-    while (this.outboundIceQueue.length) {
-      const event = this.outboundIceQueue.shift();
-      Logger.trace("[mcs-media-session] Dispatching queue ICE", event);
-      this.emitter.emit(C.EVENT.MEDIA_STATE.ICE, event);
-    }
+    // Session-wide event listener
+    this.medias.forEach(m => {
+      m.onEvent(eventName);
+    });
   }
 
   getMediaInfo () {
+    const medias = this.medias.map(m => m.getMediaInfo());
     const mediaInfo = {
+      mediaSessionId: this.id,
       mediaId: this.id,
+      medias,
       roomId: this.roomId,
       userId: this.userId,
       name: this._name,
@@ -289,6 +202,7 @@ module.exports = class MediaSession {
       muted: this._muted,
       mediaTypes: this._mediaTypes,
     };
+
     return mediaInfo;
   }
 

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -1,0 +1,198 @@
+/**
+ * @classdesc
+ * Model class for external devices
+ */
+
+'use strict'
+
+const C = require('../constants/constants');
+const SdpWrapper = require('../utils/sdp-wrapper');
+const Balancer = require('../media/balancer');
+const rid = require('readable-id');
+const config = require('config');
+const Logger = require('../utils/logger');
+const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
+const MEDIA_SPECS = config.get('conference-media-specs');
+const { handleError } = require('../utils/util');
+const LOG_PREFIX = '[mcs-media]';
+
+module.exports = class Media {
+  constructor(
+    roomId,
+    userId,
+    mediaSessionId,
+    type,
+    adapter,
+    adapterElementId,
+    host,
+    options = {}
+  ) {
+    // {SdpWrapper} SdpWrapper
+    this.id = rid();
+    this.roomId = roomId;
+    this.userId = userId;
+    this.mediaSessionId = mediaSessionId;
+    this.type = type;
+    this.adapter = adapter;
+    this.adapterElementId = adapterElementId;
+    this.host = host;
+    this.name = options.name;
+    this.customIdentifier = options.customIdentifier;
+    this.muted = false;
+    this.mediaTypes;
+    this.status = C.STATUS.STARTED;
+
+    // API event buffers for this media session
+    this.eventQueue = [];
+    this.outboundIceQueue = [];
+    this._mediaStateSubscription = false;
+    this._iceSubscription = false;
+
+    Logger.trace(LOG_PREFIX, "New", type, "media", this.getMediaInfo());
+  }
+
+  async trackMedia () {
+    this.adapter.on(C.EVENT.MEDIA_STATE.MEDIA_EVENT+this.adapterElementId, this._dispatchMediaStateEvent.bind(this));
+    this.adapter.on(C.EVENT.MEDIA_STATE.ICE+this.adapterElementId, this._dispatchIceCandidate.bind(this));
+
+    this.adapter.trackMediaState(this.adapterElementId, this.type);
+
+    const notifyHostOffline = (hostId) => {
+      if (this.host && this.host.id === hostId) {
+        let event = {};
+        event.state = { name: C.EVENT.MEDIA_SERVER_OFFLINE, details: 'offline' };
+        event.mediaId = this.id;
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, event);
+
+        this.balancer.removeListener(C.EVENT.MEDIA_SERVER_OFFLINE, notifyHostOffline);
+      }
+    };
+
+    const notifyHostOnline = (hostId) => {
+      if (this.host && this.host.id === hostId) {
+        let event = {};
+        event.state = { name : C.EVENT.MEDIA_SERVER_ONLINE, details: 'online' };
+        event.mediaId = this.id;
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, event);
+      }
+    };
+
+    Balancer.on(C.EVENT.MEDIA_SERVER_OFFLINE, notifyHostOffline);
+    Balancer.on(C.EVENT.MEDIA_SERVER_ONLINE, notifyHostOnline);
+
+    Balancer.on(C.EVENT.MEDIA_SERVER_ONLINE, () => {
+      let event = {};
+      event.state = C.EVENT.MEDIA_SERVER_ONLINE;
+      event.mediaId = this.id;
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.SERVER_STATE, event);
+    });
+
+    this.adapter.once(C.EVENT.MEDIA_DISCONNECTED+this.adapterElementId, this.stop.bind(this));
+
+
+    Logger.info(LOG_PREFIX, "New media session", this.id, "in room", this.roomId, "started with media server endpoint", this.adapterElementId);
+  }
+
+  async stop () {
+    if (this.status === C.STATUS.STARTED || this.status=== C.STATUS.STARTING) {
+      this.status = C.STATUS.STOPPING;
+      try {
+        await this.adapter.stop(this.roomId, this.type, this.adapterElementId);
+
+        if (this.hasVideo) {
+          Balancer.decrementHostStreams(this.host.id, 'video');
+        }
+
+        this.status = C.STATUS.STOPPED;
+        Logger.info(LOG_PREFIX, "Session", this.id, "stopped with status", this.status);
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_DISCONNECTED, { roomId: this.roomId, mediaId: this.id, mediaSessionId: this.mediaSessionId });
+
+        return Promise.resolve();
+      }
+      catch (err) {
+        err = this._handleError(err);
+        return Promise.reject(err);
+      }
+    } else {
+      return Promise.resolve();
+    }
+  }
+
+  onEvent (eventName) {
+    switch (eventName) {
+      case C.EVENT.MEDIA_STATE.MEDIA_EVENT:
+        this._mediaStateSubscription = true;
+        this._flushMediaStateEvents();
+        break;
+      case C.EVENT.MEDIA_STATE.ICE:
+        this._iceSubscription = true;
+        this._flushIceEvents();
+        break;
+      default: Logger.trace("[mcs-media-session] Unknown event subscription", eventName);
+    }
+  }
+
+  _dispatchMediaStateEvent (event) {
+    if (!this._mediaStateSubscription) {
+      Logger.debug("[mcs-media-session] Media session", this.id, "queuing event", { mediaId: this.id, ...event });
+      this.eventQueue.push(event);
+    }
+    else {
+      // TODO mediaId could be this.id?
+      event = { mediaSessionId: this.mediaSessionId, mediaId: this.mediaSessionId, ...event };
+      Logger.trace("[mcs-media-session] Dispatching", event);
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, event);
+    }
+  }
+
+  _dispatchIceCandidate (event) {
+    if (!this._iceSubscription) {
+      Logger.debug("[mcs-media-session] Media session", this.id, "queuing event", event);
+      this.outboundIceQueue.push({ mediaId: this.id, ...event});
+    }
+    else {
+      // TODO mediaId should be this.id?
+      event = { mediaSessionId: this.mediaSessionId, mediaId: this.mediaSessionId, ...event };
+      Logger.trace("[mcs-media-session] Dispatching ICE", event);
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_STATE.ICE, event);
+    }
+  }
+
+  _flushMediaStateEvents () {
+    Logger.debug("[mcs-media-session] Flushing session", this.id, "media state queue");
+
+    while (this.eventQueue.length) {
+      const event = this.eventQueue.shift();
+      Logger.trace("[mcs-media-session] Dispatching queued media state event", event);
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_STATE.MEDIA_EVENT, event);
+    }
+  }
+
+  _flushIceEvents () {
+    Logger.debug("[mcs-media-session] Flushing session", this.id, "ICE queue", this.outboundIceQueue);
+
+    while (this.outboundIceQueue.length) {
+      const event = this.outboundIceQueue.shift();
+      Logger.trace("[mcs-media-session] Dispatching queue ICE", event);
+      GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_STATE.ICE, event);
+    }
+  }
+
+  getMediaInfo () {
+    const mediaInfo = {
+      mediaId: this.id,
+      roomId: this.roomId,
+      userId: this.userId,
+      name: this.name,
+      customIdentifier: this.customIdentifier? this.customIdentifier : undefined,
+      muted: this.muted,
+      mediaTypes: this.mediaTypes,
+    };
+    return mediaInfo;
+  }
+
+  _handleError (error) {
+    this._status = C.STATUS.STOPPED;
+    return handleError(LOG_PREFIX, error);
+  }
+}

--- a/lib/mcs-core/lib/model/media.js
+++ b/lib/mcs-core/lib/model/media.js
@@ -39,7 +39,7 @@ module.exports = class Media {
     this.name = options.name;
     this.customIdentifier = options.customIdentifier;
     this.muted = false;
-    this.mediaTypes;
+    this.mediaTypes = {};
     this.status = C.STATUS.STARTED;
 
     // API event buffers for this media session

--- a/lib/mcs-core/lib/model/sdp-media.js
+++ b/lib/mcs-core/lib/model/sdp-media.js
@@ -1,0 +1,91 @@
+/**
+ * @classdesc
+ * Model class for external devices
+ */
+
+'use strict'
+
+const C = require('../constants/constants');
+const SdpWrapper = require('../utils/sdp-wrapper');
+const rid = require('readable-id');
+const Media = require('./media');
+const Balancer = require('../media/balancer');
+const config = require('config');
+const Logger = require('../utils/logger');
+const MEDIA_SPECS = config.get('conference-media-specs');
+
+module.exports = class SDPMedia extends Media {
+  constructor(
+    room,
+    user,
+    mediaSessionId,
+    offer,
+    answer,
+    type,
+    adapter,
+    adapterElementId,
+    host,
+    options
+  ) {
+    super(room, user, mediaSessionId, type, adapter, adapterElementId, host, options);
+    Logger.info("[mcs-sdp-media] New session with options", type);
+    // {SdpWrapper} SdpWrapper
+    this.offer;
+    this.answer;
+
+    if (offer) {
+      this.setOffer(offer);
+    }
+
+    if (answer) {
+      this.setAnswer(answer);
+    }
+
+    this._updateHostLoad();
+  }
+
+  setOffer (offer) {
+    if (offer) {
+      if (this.offer) {
+        this._shouldRenegotiate = true;
+      }
+
+      this.offer = new SdpWrapper(offer, MEDIA_SPECS, this._mediaProfile);
+    }
+  }
+
+  setAnswer (answer) {
+    if (answer) {
+      // Manual NAT traversal for when the media server is behind NAT
+      if (this.type !== C.MEDIA_TYPE.WEBRTC) {
+        answer = SdpWrapper.nonPureReplaceServerIpv4(answer, this.host.ip);
+      }
+
+      this.answer = new SdpWrapper(answer, MEDIA_SPECS, this._mediaProfile);
+    }
+  }
+
+  addIceCandidate (candidate) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await this.adapter.addIceCandidate(this.adapterElementId, candidate);
+        resolve();
+      }
+      catch (err) {
+        return reject(this._handleError(err));
+      }
+    });
+  }
+
+  _updateHostLoad () {
+    if (this.answer.hasAvailableVideoCodec()) {
+      Balancer.incrementHostStreams(this.host.id, 'video');
+      this.hasVideo = true;
+    }
+
+    if (this.answer.hasAvailableAudioCodec()) {
+      Balancer.incrementHostStreams(this.host.id, 'audio');
+      this.hasAudio = true;
+    }
+  }
+}

--- a/lib/mcs-core/lib/model/sdp-media.js
+++ b/lib/mcs-core/lib/model/sdp-media.js
@@ -62,6 +62,8 @@ module.exports = class SDPMedia extends Media {
       }
 
       this.answer = new SdpWrapper(answer, MEDIA_SPECS, this._mediaProfile);
+      this.mediaTypes.video = this.answer.hasAvailableVideoCodec();
+      this.mediaTypes.audio = this.answer.hasAvailableAudioCodec();
     }
   }
 

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -63,7 +63,7 @@ module.exports = class SDPSession extends MediaSession {
     const audioDescription = this._offer.audioSdp;
     Logger.trace('[mcs-sdp-session] Defiling this beloved SDP for session', this.id, videoDescription, audioDescription);
     const videoMedias = await videoAdapter.negotiate(this.roomId, this.userId, this.id,
-      videoDescripton, this._type, this._options);
+      videoDescription, this._type, this._options);
     const audioMedias = await audioAdapter.negotiate(this.roomId, this.userId, this.id,
       audioDescription, this._type, this._options);
 
@@ -173,7 +173,15 @@ module.exports = class SDPSession extends MediaSession {
       return;
     }
 
-    this.medias.forEach(m => {
+    // Some endpoints demand that the audio description be first in order to work
+    const headDescription = this.medias.filter(m => m.mediaTypes.audio);
+    const remainingDescriptions = this.medias.filter(m => !m.mediaTypes.audio);
+
+    if (headDescription && headDescription[0]) {
+      body += headDescription[0].answer.removeSessionDescription(headDescription[0].answer._plainSdp);
+    }
+
+    remainingDescriptions.forEach(m => {
       const partialAnswer = m.answer;
       if (partialAnswer) {
         body += partialAnswer.removeSessionDescription(partialAnswer._plainSdp)

--- a/lib/mcs-core/lib/model/sdp-session.js
+++ b/lib/mcs-core/lib/model/sdp-session.js
@@ -9,12 +9,15 @@ const C = require('../constants/constants');
 const SdpWrapper = require('../utils/sdp-wrapper');
 const rid = require('readable-id');
 const MediaSession = require('./media-session');
+const SDPMedia = require('./sdp-media');
 const config = require('config');
 const Logger = require('../utils/logger');
 const AdapterFactory = require('../adapters/adapter-factory');
 const MEDIA_SPECS = config.get('conference-media-specs');
+const GLOBAL_EVENT_EMITTER = require('../utils/emitter');
+const Balancer = require('../media/balancer');
 
-module.exports = class SdpSession extends MediaSession {
+module.exports = class SDPSession extends MediaSession {
   constructor(
     offer = null,
     room,
@@ -23,7 +26,7 @@ module.exports = class SdpSession extends MediaSession {
     options
   ) {
     super(room, user, type, options);
-    Logger.info("[mcs-sdp-session] New session with options", type, options);
+    this.medias = [];
     // {SdpWrapper} SdpWrapper
     this._offer;
     this._answer;
@@ -59,134 +62,39 @@ module.exports = class SdpSession extends MediaSession {
     const videoDescription = this._offer.mainVideoSdp;
     const audioDescription = this._offer.audioSdp;
     Logger.trace('[mcs-sdp-session] Defiling this beloved SDP for session', this.id, videoDescription, audioDescription);
-    const videoAnswer = await videoAdapter.processOffer(this.videoMediaElement,
-      videoDescription, { name: this._name });
-    const audioAnswer = await audioAdapter.processOffer(this.audioMediaElement,
-      audioDescription, { name: this._name });
+    const videoMedias = await videoAdapter.negotiate(this.roomId, this.userId, this.id,
+      videoDescripton, this._type, this._options);
+    const audioMedias = await audioAdapter.negotiate(this.roomId, this.userId, this.id,
+      audioDescription, this._type, this._options);
 
-    audioAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.audioMediaElement, this.stop.bind(this));
-    videoAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.videoMediaElement, this.stop.bind(this))
+    this.medias = this.medias.concat(videoMedias, audioMedias);
 
-    this.setAnswer(audioAnswer + this._offer.removeSessionDescription(videoAnswer));
-    return this._answer._plainSdp;
+    const answer = this.getAnswer();
+    this.setAnswer(answer);
+    return answer;
 
   }
 
   renegotiateStreams () {
     return new Promise(async (resolve, reject) => {
       try {
+        // For now we only support renegotiation for content streams
         const {
-          videoAdapter,
-          audioAdapter,
           contentAdapter
         } = this._adapters;
 
         if (this._offer.contentVideoSdp) {
-          const { mediaElement, host } = await contentAdapter.createMediaElement(this.roomId, this._type, this._options);
+          const contentMedias = await contentAdapter.negotiate(this.roomId, this.userId, this.id,
+            this._offer.contentVideoSdp, this._type, this._options);
 
-          this.contentMediaElement = mediaElement;
-          this.contentHost = host;
-          let contentAnswer = await videoAdapter.processOffer(this.contentMediaElement,
-            this._offer.contentVideoSdp,
-            { name: this._name }
-          );
-          contentAnswer = this._offer.removeSessionDescription(contentAnswer);
-          this.setAnswer(this._answer._plainSdp + contentAnswer + "a=content:slides\r\n");
-          return resolve(this._answer._plainSdp);
+          this.medias = this.medias.concat(contentMedias);
+
+          const contentAnswer = this.getAnswer();
+          this.setAnswer(contentAnswer + "a=content:slides\r\n");
+          return resolve(answer);
         }
       } catch (e) {
         return reject(this._handleError(e));
-      }
-    });
-  }
-
-  async _createMainMediaElement (referenceDescriptor) {
-    let mediaElement, host;
-    const {
-      videoAdapter,
-      audioAdapter,
-      contentAdapter
-    } = this._adapters;
-
-    if ((referenceDescriptor && referenceDescriptor.hasVideo) ||
-      !AdapterFactory.isComposedAdapter(this._adapter)) {
-      ({ mediaElement, host } = await videoAdapter.createMediaElement(this.roomId, this._type, this._options));
-
-      this.videoMediaElement = mediaElement;
-      this.videoHost = host;
-
-      // Audio and video are bundled
-      if (!AdapterFactory.isComposedAdapter(this._adapter)) {
-        this.audioMediaElement = mediaElement;
-        this.audioHost = host;
-      }
-
-      if (this._mediaProfile === 'content') {
-        this.contentMediaElement = mediaElement;
-        this.contentHost = host;
-      }
-
-      this._upstartMediaElement(videoAdapter, this.videoMediaElement);
-      return { mediaElement, host };
-    }
-  }
-
-  async _createAudioMediaElement (referenceDescriptor) {
-    let mediaElement, host;
-    const {
-      videoAdapter,
-      audioAdapter,
-      contentAdapter
-    } = this._adapters;
-
-    if ((referenceDescriptor && referenceDescriptor.hasAudio) ||
-      AdapterFactory.isComposedAdapter(this._adapter)) {
-      ({ mediaElement, host } = await audioAdapter.createMediaElement(this.roomId, this._type, this._options));
-
-      this.audioMediaElement = mediaElement;
-      this.audioHost = host;
-
-      this._upstartMediaElement(audioAdapter, this.audioMediaElement);
-
-      return { mediaElement, host };
-    }
-  }
-
-  async _createContentMediaElement (referenceDescriptor) {
-    let mediaElement, host;
-    const {
-      videoAdapter,
-      audioAdapter,
-      contentAdapter
-    } = this._adapters;
-
-    if ((referenceDescriptor && referenceDescriptor.hasContent) ||
-      AdapterFactory.isComposedAdapter(this._adapter)) {
-      ({ mediaElement, host } = await contentAdapter.createMediaElement(this.roomId, this._type, this._options));
-
-      this.contentMediaElement= mediaElement;
-      this.contentHost = host;
-
-      this._upstartMediaElement(audioAdapter, this.audioMediaElement);
-
-      return { mediaElement, host };
-    }
-  }
-
-  _createMediaElements () {
-    return new Promise(async (resolve, reject) => {
-      try {
-        let mediaElement, host;
-
-        const referenceDescriptor = this._offer? this._offer : this._answer;
-        await this._createMainMediaElement(referenceDescriptor);
-        await this._createAudioMediaElement(referenceDescriptor);
-        await this._createContentMediaElement(referenceDescriptor);
-        return resolve();
-      }
-      catch (err) {
-        err = this._handleError(err);
-        reject(err);
       }
     });
   }
@@ -206,25 +114,17 @@ module.exports = class SdpSession extends MediaSession {
           return resolve(answer);
         }
 
-        await this._createMediaElements();
-
         if (AdapterFactory.isComposedAdapter(this._adapter)) {
           answer = await this._defileAndProcess(this._offer);
         } else {
           // The adapter is the same for all media types, so either one will suffice
           let offer = this._offer ? this._offer.plainSdp : null;
-          if (this.videoMediaElement) {
-            answer = await videoAdapter.processOffer(this.videoMediaElement,
-              offer,
-              { name: this._name }
-            );
-            videoAdapter.once(C.EVENT.MEDIA_DISCONNECTED+this.videoMediaElement, this.stop.bind(this));
-          }
-
+          this.medias = await videoAdapter.negotiate(this.roomId, this.userId, this.id, offer, this._type, this._options);
+          answer = this.getAnswer();
           this.setAnswer(answer);
         }
 
-        answer = this._answer._plainSdp? this._answer._plainSdp : null;
+        answer = (this._answer && this._answer._plainSdp)? this._answer._plainSdp : null;
 
         Logger.trace('[mcs-sdp-session] The wizard responsible for this session', this.id, 'processed the following answers', answer);
 
@@ -238,19 +138,8 @@ module.exports = class SdpSession extends MediaSession {
           this._mediaTypes.audio = this._answer.hasAvailableAudioCodec();
         }
 
-        // Manual NAT traversal for when the media server is behind NAT
-        if (answer && this._type !== 'WebRtcEndpoint') {
-          answer = SdpWrapper.nonPureReplaceServerIpv4(answer, this.videoHost.ip);
-        }
-
-        if (this._type === 'WebRtcEndpoint') {
-          await videoAdapter.gatherCandidates(this.videoMediaElement);
-        }
-
-        this._updateHostLoad();
-
         Logger.trace("[mcs-sdp-session] Answer SDP for session", this.id, answer);
-        this.emitter.emit(C.EVENT.MEDIA_CONNECTED, this.getMediaInfo());
+        GLOBAL_EVENT_EMITTER.emit(C.EVENT.MEDIA_CONNECTED, this.getMediaInfo());
 
         return resolve(answer);
       }
@@ -263,13 +152,11 @@ module.exports = class SdpSession extends MediaSession {
   addIceCandidate (candidate) {
     return new Promise(async (resolve, reject) => {
       try {
-        const {
-          videoAdapter,
-          audioAdapter,
-          contentAdapter
-        } = this._adapters;
-
-        await videoAdapter.addIceCandidate(this.videoMediaElement, candidate);
+        this.medias.forEach(m => {
+          if (m.type === C.MEDIA_TYPE.WEBRTC) {
+            m.addIceCandidate(candidate);
+          }
+        });
         resolve();
       }
       catch (err) {
@@ -278,21 +165,26 @@ module.exports = class SdpSession extends MediaSession {
     });
   }
 
+  getAnswer () {
+    let header = '', body = '';
+    if (this.medias[0]) {
+      header = this.medias[0].answer.sessionDescriptionHeader;
+    } else {
+      return;
+    }
+
+    this.medias.forEach(m => {
+      const partialAnswer = m.answer;
+      if (partialAnswer) {
+        body += partialAnswer.removeSessionDescription(partialAnswer._plainSdp)
+      }
+    });
+
+    return header + body;
+  }
+
   _hasAvailableCodec () {
     return (this._offer.hasAvailableVideoCodec() === this._answer.hasAvailableVideoCodec()) &&
       (this._offer.hasAvailableAudioCodec() === this._answer.hasAvailableAudioCodec());
-  }
-
-
-  _updateHostLoad () {
-    if (this._answer.hasAvailableVideoCodec()) {
-      this.balancer.incrementHostStreams(this.videoHost.id, 'video');
-      this.hasVideo = true;
-    }
-
-    if (this._answer.hasAvailableAudioCodec()) {
-      this.balancer.incrementHostStreams(this.audioHost.id, 'audio');
-      this.hasAudio = true;
-    }
   }
 }

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -19,11 +19,11 @@ const { handleError } = require('../utils/util');
 const LOG_PREFIX = "[mcs-user]";
 
 module.exports = class User {
-  constructor(roomId, type, name = 'default') {
+  constructor(roomId, type, params = {}) {
     this.id = rid();
     this.roomId = roomId;
     this.type = type;
-    this.name = name;
+    this.name = params.name ? params.name : this.id;
     this._mediaSessions = {}
   }
 

--- a/lib/mcs-core/lib/model/user.js
+++ b/lib/mcs-core/lib/model/user.js
@@ -24,7 +24,6 @@ module.exports = class User {
     this.roomId = roomId;
     this.type = type;
     this.name = name;
-    this.emitter = GLOBAL_EVENT_EMITTER;
     this._mediaSessions = {}
   }
 
@@ -204,13 +203,16 @@ module.exports = class User {
     return userMedias;
   }
 
-  _trackMediaDisconnection(media) {
-    media.emitter.once(C.EVENT.MEDIA_DISCONNECTED, (mediaId) => {
-      if (mediaId === media.id) {
-        Logger.info("[mcs-user] Media stopped.");
-        delete this._mediaSessions[mediaId] ;
+  _trackMediaDisconnection(mediaSession) {
+    const deleteMedia = ({ mediaSessionId }) => {
+      if (mediaSessionId === mediaSession.id) {
+        Logger.info("[mcs-user] Media", mediaSessionId, "stopped.");
+        delete this._mediaSessions[mediaSessionId] ;
+        GLOBAL_EVENT_EMITTER.removeListener(C.EVENT.MEDIA_DISCONNECTED, deleteMedia);
       }
-    });
+    };
+
+    GLOBAL_EVENT_EMITTER.on(C.EVENT.MEDIA_DISCONNECTED, deleteMedia);
   }
 
   _handleError (error) {

--- a/lib/mcs-core/lib/utils/sdp-wrapper.js
+++ b/lib/mcs-core/lib/utils/sdp-wrapper.js
@@ -207,6 +207,26 @@ module.exports = class SdpWrapper {
   }
 
   /**
+   * Given a SDP, return all video descriptors
+   * @param  {string} sdp The Session Descriptor
+   * @return {Array.String} Video content descriptors
+   */
+  static getPartialDescriptions (descriptor) {
+    let res = transform.parse(descriptor);
+    let descriptorsList = []
+    res.media = res.media.filter((ml) => { return ml.type == "video" || ml.type === 'audio'}); //&& ml.invalid[0].value != 'content:slides'});
+    res.media.forEach(media => {
+      let partialSDP = Object.assign({}, res);
+      partialSDP.media = [media];
+      const stringifiedPartialSDP = transform.write(partialSDP);
+      if (stringifiedPartialSDP && stringifiedPartialSDP !== '') {
+        descriptorsList .push(stringifiedPartialSDP);
+      }
+    });
+    return descriptorsList;
+  }
+
+  /**
    * Given a JSON SDP, remove associated crypto 'a=' lines from media lines
    * WARNING: HACK MADE FOR FreeSWITCH ~1.4 COMPATIBILITY
    * @param  {Object} sdp The Session Descriptor JSON
@@ -328,6 +348,7 @@ module.exports = class SdpWrapper {
     this.sessionDescriptionHeader = SdpWrapper.getSessionDescription(description);
     this.audioSdp =  SdpWrapper.getAudioDescription(description);
     this.mainVideoSdp = this.getMainDescription(description);
+    this.partialDescriptors = SdpWrapper.getPartialDescriptions(description);
     this.contentVideoSdp = this.getContentDescription(description);
 
     return;


### PR DESCRIPTION
- Standardized negotiation calls for the adapters, should decouple the application from media server particularities even more now
- Usable support for multiple medias per session handling. This makes SFU compatible with Suite/Multipresença regarding media negotiation. There's still work to do in the suite repo, though, to make it conform to some of our data formats and event model
- Medias are now single units grouped under media sessions. This was done to make it easier to handle adapter particularities, make the code cleaner and a bit less if-fy. They're generated in a standard format by each media server adapter, and that should provide a proper data interfacing between our model and an adapter's model. This will also make some things like SSRC muxing (Jitsi, Janus) or SDP dismembering (Kurento) transparent.
- Renegotiation now handles outbound content (e.g.: Mconf -> external endpoint)
- We now support media creation with late descriptors (e.g.: SIP INVITE without SDP)